### PR TITLE
Correctly check for systemd not installed.

### DIFF
--- a/prog/lnet
+++ b/prog/lnet
@@ -271,7 +271,7 @@ function ethernet_menu() {
       M)      ethernet_manage_device $1;;
       D)
         if confirm "Are you sure you wish to delete $1?" "--defaultno"; then
-          if [ -n $SYSTEMDUNITDIR ]; then
+          if [ -n "$SYSTEMDUNITDIR" ]; then
             systemd_disable_existing ${1}
           fi
           rm -f "$CONFIG_DIR/$1"

--- a/prog/lservices
+++ b/prog/lservices
@@ -205,7 +205,7 @@ main_menu() {
   if [ $? != 0 ] ; then
     return
   fi
-  if [ -n $SYSTEMDUNITDIR ]; then
+  if [ -n "$SYSTEMDUNITDIR" ]; then
     service_menu_systemd $(echo $action | sed 's/ //g')
   else
     service_menu $(echo $action | sed 's/ //g')


### PR DESCRIPTION
test -n succeeds on a non existing variable.
