### PR TITLE
main_menu: Don't exit with error code just because user selected "exit"

### DIFF
--- a/lib/lnet/menus.lnet.sh
+++ b/lib/lnet/menus.lnet.sh
@@ -405,7 +405,7 @@ main_menu() {
 						  $(echo -en $LIST)                 \
 						  "A"  "Add a network device"       \
 						  "N"  "Setup host name"            \
-						  $(echo -en $MANAGE)) || return
+						  $(echo -en $MANAGE)) || return 0
 		case "$COMMAND" in
             [0-9]*) dev_edit_menu ${INTERFACES[$COMMAND]}      ;;
             A)      dev_add_menu                               ;;


### PR DESCRIPTION
It turns out that after "dialog" exits with a 1 exit code (indicating user selected exit, rather than an actual error), the "return" picks up that error code, returns that to the main script, which also in turn returns the last exit code, making the lunar-installer think that lnet exited with an error status.

This fixes that so that lnet run from the installer doesn't report spurious errors.