### PR TITLE
Add device option: Set new device to DHCP before editing it

### DIFF
--- a/lib/lnet/menus.lnet.sh
+++ b/lib/lnet/menus.lnet.sh
@@ -192,6 +192,8 @@ dev_add_menu() {
                      "${devices_menu[@]}") || return
     dev=${devices[$[result-1]]}
 
+    set_dev_config $dev dhcp
+
     dev_config_menu $dev
 }
 


### PR DESCRIPTION
This means that as soon as you select a device for configuration, its config is already saved, so if you just want DHCP, you can then bounce out of the config menu and your device config will still be saved. No need to switch between static and DHCP just to force it to save its config.