### PR TITLE
device_config: Change default netmask for new device to /24

### DIFF
--- a/lib/lnet/device_config.lnet.sh
+++ b/lib/lnet/device_config.lnet.sh
@@ -68,7 +68,7 @@ get_dev_config() {
     local config_file="$CONFIG_DIR/${device}.network"
     local DHCP_enabled=true
     local IP_Address=0.0.0.0
-    local Netmask=255.255.255.255
+    local Netmask=255.255.255.0
     local Gateway=0.0.0.0
     local CIDR
     local DNS1


### PR DESCRIPTION
The previous default, /32, seems to have been causing confusion because if you configure an interface with a /32, it doesn't set a default route.